### PR TITLE
Improve GitHub project display and naming

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -575,7 +575,7 @@ export default function ClientPageRoot() {
           };
           const newProject: Project = {
             id: targetProjectId,
-            name: `${selectedRepoFullName} (${branchName})`, // Default name
+            name: `${selectedRepoFullName} / ${branchName}`, // More readable format
             sourceType: 'github',
             githubRepoFullName: selectedRepoFullName,
             githubBranch: branchName,

--- a/components/RecentProjectsDisplay.tsx
+++ b/components/RecentProjectsDisplay.tsx
@@ -13,7 +13,7 @@ interface RecentProjectsDisplayProps {
   maxInitialDisplay?: number; // Optional: Max projects to show before "Show More"
 }
 
-const MAX_RECENT_PROJECTS_VISIBLE_DEFAULT = 5;
+const MAX_RECENT_PROJECTS_VISIBLE_DEFAULT = 3;
 
 const RecentProjectsDisplay: React.FC<RecentProjectsDisplayProps> = ({
   projects,


### PR DESCRIPTION
Improve recent projects list by cleaning GitHub project names and reducing default visible entries.

This PR addresses the user's request for a cleaner, shorter, and more readable recent projects list, making the existing auto-loading functionality more transparent.